### PR TITLE
[NLP] RAG  — fix by rm conflicting libs

### DIFF
--- a/notebooks/nlp/rag.ipynb
+++ b/notebooks/nlp/rag.ipynb
@@ -34,6 +34,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# remove some conflicting and unnecessary deps\n",
+    "%pip uninstall gcsfs grpcio-status -y -q\n",
+    "\n",
     "%pip install \"fed-rag[huggingface]\" bitsandbytes -q"
    ]
   },


### PR DESCRIPTION
# [NLP] `RAG`

<!-- Example: [NLP] Add BERT Fine-tuning Notebook -->
<!-- Example: [CV] Fix ResNet Training Example -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] New Notebook
- [x] Update to Existing Notebook
- [ ] Other (please describe):

## Related Issue

<!-- Link to the related issue -->

Fixes #

## Book

<!-- Indicate which book this PR affects -->

- [ ] fundamentals
- [x] nlp
- [ ] cv
- [ ] rl
- [ ] fl
- [ ] responsible_ai

## Description

Dependencies on Google colab default venv conflict with `fed_rag[huggingface]`. Removing colab's installed versions resolves this conflict.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] Notebook is named to match its corresponding pocket reference
- [ ] Dependencies are installed using `%pip install` commands
- [ ] Code cells are well-commented
- [ ] All code cells run sequentially without errors
- [ ] Pre-commit hooks pass without errors
- [ ] I have linked to related issues

## Additional Context

<!-- Add any other context about the PR here -->
